### PR TITLE
Bump to lts 18 18

### DIFF
--- a/src/Squeal/PostgreSQL/Hspec.hs
+++ b/src/Squeal/PostgreSQL/Hspec.hs
@@ -8,14 +8,12 @@ Tests can be written with 'itDB' which is wrapper around 'it' that uses the pass
 
 The libary also provides a few other functions for more fine grained control over running transactions in tests.
 -}
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds   #-}
 {-# LANGUAGE RankNTypes       #-}
 {-# LANGUAGE RecordWildCards  #-}
 {-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE TypeInType       #-}
-{-# LANGUAGE TypeOperators    #-}
 module Squeal.PostgreSQL.Hspec
 where
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.31
+resolver: lts-18.18
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Use LTS 18.18 in this project so it can be used by other projects that live in the shiny future.